### PR TITLE
Fixed building on Macintosh and Linux

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -328,6 +328,12 @@ bool c_read_full_path( const char* path, struct str* str ) {
 #include <dirent.h>
 #include <sys/stat.h>
 
+#ifdef __APPLE__
+#include <limits.h> // PATH_MAX on OS X is defined in limits.h
+#elif defined __linux__
+#include <linux/limits.h> // And on Linux it is in linux/limits.h
+#endif
+
 bool c_read_full_path( const char* path, struct str* str ) {
    str_grow( str, PATH_MAX + 1 );
    if ( realpath( path, str->value ) ) {


### PR DESCRIPTION
Now builds on OS X (tested on 10.9.3 with Xcode 5.1.1 and clang-503.0.40) and Linux (tested on Fedora 20 (3.14.4-200.fc20.i686) with gcc 4.9.0).
