### PR TITLE
Complain when trying to parse a very large int

### DIFF
--- a/src/task.h
+++ b/src/task.h
@@ -1412,6 +1412,7 @@ void t_read_region( struct task* );
 void t_read_import( struct task*, struct list* );
 void t_import( struct task*, struct import* );
 int t_extract_literal_value( struct task* );
+int t_convert_string_to_literal( struct task* task, int base );
 void t_align_4byte( struct task* );
 struct source* t_load_included_source( struct task* );
 void t_make_main_lib( struct task* );


### PR DESCRIPTION
Issue an error message when trying to parse integers larger than 2^32

    int a = 161803398874989484820458683;

Error: "numeric value `161803398874989484820458683` is too large"